### PR TITLE
Implemented Dispose pattern for both Buffer and BufferEvent with no fina...

### DIFF
--- a/Oars/Buffer.cs
+++ b/Oars/Buffer.cs
@@ -6,6 +6,7 @@ namespace Oars
 {
     public sealed class Buffer : IDisposable
     {
+        bool disposed;
         IntPtr handle;
         bool ownsBuffer;
 
@@ -22,10 +23,20 @@ namespace Oars
             this.handle = handle;
         }
 
+        void Dispose(bool disposing)
+        {
+            if (!disposed)
+            {
+                disposed = true;
+
+                if (ownsBuffer)
+                    evbuffer_free(handle);
+            }
+        }
+
         public void Dispose()
         {
-            if (ownsBuffer)
-                evbuffer_free(handle);
+            Dispose(true);
         }
 
         public bool Add(byte[] data, int offset, int count)
@@ -40,8 +51,6 @@ namespace Oars
         {
             if (offset + count > data.Length)
                 throw new Exception("offset + count > data.Length");
-
-            var c = new IntPtr(count);
 
             unsafe {
                 fixed (byte *ptr = &data[0])

--- a/Oars/EventBase.cs
+++ b/Oars/EventBase.cs
@@ -6,7 +6,8 @@ namespace Oars
     public enum LoopOptions : int
     {
         Once = 0x01,
-        NonBlock = 0x02
+        NonBlock = 0x02,
+        NoExitOnEmpy = 0x04
     }
 
     public sealed class EventBase : IDisposable

--- a/Oars/EventSyncContext.cs
+++ b/Oars/EventSyncContext.cs
@@ -1,0 +1,43 @@
+﻿using System.Threading;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace Oars
+{
+  public sealed class EventSyncContext : SynchronizationContext
+  {
+        readonly BlockingCollection<KeyValuePair<SendOrPostCallback,object>> m_queue = 
+            new BlockingCollection<KeyValuePair<SendOrPostCallback,object>>();
+
+        EventBase eventBase = new EventBase();
+
+        public EventBase EventBase
+        {
+            get
+            {
+                return eventBase;
+            }
+        }
+
+        public override void Post(SendOrPostCallback d, object state)
+        {
+            m_queue.Add(new KeyValuePair<SendOrPostCallback,object>(d, state));
+        }
+
+        public void RunOnCurrentThread()
+        {
+            KeyValuePair<SendOrPostCallback, object> workItem;
+            while (true)
+            {
+                while (m_queue.TryTake(out workItem, 1))
+                    workItem.Key(workItem.Value);
+                eventBase.Loop(LoopOptions.NonBlock);
+            }
+        }
+
+        public void Complete() {
+            m_queue.CompleteAdding();
+        }
+    }
+}
+

--- a/Oars/Interop.cs
+++ b/Oars/Interop.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 
 namespace Oars
 {
-    internal struct timeval
+    struct timeval
     {
         public int tv_sec;
         public int tv_usec;
@@ -71,7 +71,7 @@ namespace Oars
     [StructLayout(LayoutKind.Sequential)]
     struct in_addr
     {
-        public long s_addr;
+        public uint s_addr;
     }
 	
 	static class OperatingSystem
@@ -125,38 +125,15 @@ namespace Oars
 		}
     }
 
-    public static class FDExtensions
+    static class FDExtensions
     {
+        [DllImport("libc")]
+        static extern int close(IntPtr fd);
+
         public static int Close(this IntPtr fd)
         {
             return close(fd);
         }
-
-        public static int Recv(this IntPtr fd, ArraySegment<byte> buffer, int flags)
-        {
-            unsafe
-            {
-                fixed (byte* ptr = &(buffer.Array[buffer.Offset]))
-                    return recv(fd, ptr, buffer.Count, flags);
-            }
-        }
-
-        public static int Send(this IntPtr fd, ArraySegment<byte> buffer, int flags)
-        {
-            unsafe {
-                fixed (byte *ptr = &(buffer.Array[buffer.Offset]))
-                    return send(fd, ptr, buffer.Count, flags);
-            }
-        }
-
-        [DllImport("libc")]
-        static extern int close(IntPtr fd);
-
-        [DllImport("libc")]
-        static unsafe extern int send(IntPtr fd, byte* buffer, int length, int flags);
-
-        [DllImport("libc")]
-        static unsafe extern int recv(IntPtr fd, byte* buffer, int length, int flags);
     }
 
     // lifted this from Mono.Unix/Stdlib.cs


### PR DESCRIPTION
...lizers. The user should ensure Disposed is called when no longer needed on the main EV Loop thread.

Removed redundant IntPtr allocation in Buffer.cs.
BufferEvent delegates now saved as private fields to prevent the GC collecting these. Otherwise the native code calls back to dangling pointers.
Added bufferevent_set_timeouts.
Fixed ConnectionListener not providing correct IPEndPoint for new connections. Tested OK on Ubuntu.
Added EventSyncContext to provide a means for running an EV Loop and for posting other work you want run on the same thread.
